### PR TITLE
Minor bug fixes

### DIFF
--- a/src/config/super_resolution.yaml
+++ b/src/config/super_resolution.yaml
@@ -8,7 +8,7 @@ TRAIN:
   ]
   batch_size: 512
   width: 128
-  height: 32
+  height: 64
   epochs: 500
   cuda: True
   ngpu: 4

--- a/src/interfaces/base.py
+++ b/src/interfaces/base.py
@@ -149,7 +149,7 @@ class TextBase(object):
         if self.args.arch != 'bicubic':
             model = model.to(self.device)
             image_crit.to(self.device)
-            if cfg.ngpu > 1:
+            if cfg.ngpu >= 1:
                 model = torch.nn.DataParallel(model, device_ids=range(cfg.ngpu))
                 image_crit = torch.nn.DataParallel(image_crit, device_ids=range(cfg.ngpu))
             if self.resume is not '':


### PR DESCRIPTION
Two bugs occurred when I tried to run on my single-gpu machine:
1. While training with TextZoom Dataset, if the height is set to 32 there was a dimensionality issue as the forward pass in line 34 of file src/model/recognizer/stn_head.py expects input dimension of 32*64. Changing it to 64 solved it.
2. Training on a single CUDA system raised an Attribute error in line 231 of src/interfaces/base.py file. Changing the if statement in line 152 of src/interfaces/base.py solved it.